### PR TITLE
Install Yarn dependencies first

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,11 @@ FROM node:8.11.4
 WORKDIR /app/website
 
 EXPOSE 3000 35729
+
+COPY ./website/package.json /app/website/
+RUN yarn install
+
 COPY ./docs /app/docs
 COPY ./website /app/website
-RUN yarn install
 
 CMD ["yarn", "start"]


### PR DESCRIPTION
This pull request changes the Dockerfile to separate dependencies from the rest of the site content. As a result, rebuilds happen much faster since Yarn packages are cached.