### PR TITLE
Add underline to article links

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -1,4 +1,7 @@
 /* your custom css */
+.post > article a {
+  text-decoration: underline;
+}
 
 @media only screen and (min-device-width: 360px) and (max-device-width: 736px) {
 }


### PR DESCRIPTION
While working on #1 I noticed links are a bit difficult to read:

![Screen Shot 2019-12-12 at 12 46 23 PM](https://user-images.githubusercontent.com/58807186/70747776-8866a580-1cdd-11ea-9f99-54214291310b.png)

---

This change adds an underline to links within the main body:

![Screen Shot 2019-12-12 at 12 47 00 PM](https://user-images.githubusercontent.com/58807186/70747785-8bfa2c80-1cdd-11ea-954a-cd096e890449.png)

